### PR TITLE
Update Cascalog dependency to 1.8.7-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :source-path "src/clj"
   :dependencies [[org.clojure/clojure "1.2.0"]
                  [org.clojure/clojure-contrib "1.2.0"]
-                 [cascalog "1.3.0-SNAPSHOT"]
+                 [cascalog "1.8.7-SNAPSHOT"]
                  ]
   :dev-dependencies [[org.apache.hadoop/hadoop-core "0.20.2-dev"]]
   :namespaces [cascalog-demo.demo])


### PR DESCRIPTION
I saw that the demo was using an older version of Cascalog. Your [demo tutorial](http://nathanmarz.com/blog/new-cascalog-features-outer-joins-combiners-sorting-and-more.html) still works. I haven't yet tried updating to Clojure 1.3.0, but that might be another improvement.
