### PR TITLE
Updated to Cascalog 1.10, Clojure 1.4, and Lein 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ syntax: glob
 *.settings
 *.pyc
 *.dot
+.lein-repl-history

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,10 @@
 (defproject cascalog-demo "1.0.0-SNAPSHOT"
-  :source-path "src/clj"
-  :dependencies [[org.clojure/clojure "1.2.0"]
-                 [org.clojure/clojure-contrib "1.2.0"]
-                 [cascalog "1.3.0-SNAPSHOT"]
+  :source-paths ["src/clj"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                 [cascalog "1.10.0"]
                  ]
-  :dev-dependencies [[org.apache.hadoop/hadoop-core "0.20.2-dev"]]
-  :namespaces [cascalog-demo.demo])
+  :profiles { :dev {:dependencies [[org.apache.hadoop/hadoop-core "0.20.2-dev"]]}}
+  :aot [cascalog-demo.demo]
+  :main cascalog-demo.demo
+)
+


### PR DESCRIPTION
Thank you for creating Cascalog! I updated this demo to the latest dependency versions. This also changes the hadoop command line invocation (from your blog post) from

```
hadoop jar cascalog-demo-standalone.jar cascalog_demo.demo /tmp/follows /tmp/action /tmp/results
```

to

```
hadoop jar cascalog-demo-standalone.jar /tmp/follows /tmp/action /tmp/results
```
